### PR TITLE
Remove unnecessary period when saving using the python interface

### DIFF
--- a/src/pylib/mod.rs
+++ b/src/pylib/mod.rs
@@ -22,7 +22,7 @@ impl PySeismicIndex {
 
     pub fn save(&self, path: &str) {
         let serialized = bincode::serialize(&self.inverted_index).unwrap();
-        let path = path.to_string() + ".index.seismic";
+        let path = path.to_string() + "index.seismic";
         println!("Saving ... {}", path);
         let r = fs::write(path, serialized);
         println!("{:?}", r);


### PR DESCRIPTION
When using the python interface, seismic adds an unnecessary period to the index path (which I assume is not intended). This PR removes the period