### PR TITLE
fix: Changed the BoxField to new naming convention from toolkit

### DIFF
--- a/src/inverted_index.rs
+++ b/src/inverted_index.rs
@@ -5,8 +5,8 @@ use crate::utils::{
 use crate::{
     ComponentType, QuantizedSummary, SpaceUsage, SparseDataset, SparseDatasetMut, ValueType,
 };
-use toolkit::BitFieldBoxed;
-use toolkit::bitfield::BitFieldVec;
+use toolkit::BitField;
+use toolkit::bitfield::BitFieldGrowable;
 
 use indicatif::ParallelProgressIterator;
 
@@ -995,7 +995,7 @@ impl KnnConfiguration {
 pub struct Knn {
     n_vecs: usize,
     dim: usize,
-    neighbours: BitFieldBoxed,
+    neighbours: BitField,
 }
 
 impl SpaceUsage for Knn {
@@ -1049,7 +1049,7 @@ impl Knn {
             .map(|(_distance, doc_id)| doc_id as u64)
             .collect();
 
-        let bitfield = BitFieldBoxed::from(neighbours);
+        let bitfield = BitField::from(neighbours);
 
         Self {
             n_vecs,
@@ -1078,7 +1078,7 @@ impl Knn {
             println!("We only take {:} neighbors per element!", nknn);
         }
 
-        let mut neighbours = BitFieldVec::with_capacity(knn.n_vecs, knn.neighbours.field_width());
+        let mut neighbours = BitFieldGrowable::with_capacity(knn.n_vecs, knn.neighbours.field_width());
 
         for id in 0..knn.n_vecs {
             let base_pos = id * knn.dim;
@@ -1091,7 +1091,7 @@ impl Knn {
         Knn {
             n_vecs: knn.n_vecs,
             dim: nknn,
-            neighbours: neighbours.convert_into(),
+            neighbours: neighbours.into(),
         }
     }
 

--- a/src/quantized_summary.rs
+++ b/src/quantized_summary.rs
@@ -5,7 +5,7 @@ use crate::{ComponentType, SpaceUsage, SparseDataset, ValueType};
 
 use rustc_hash::FxHashMap;
 
-use toolkit::BitFieldBoxed;
+use toolkit::BitField;
 use toolkit::EliasFano;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -14,14 +14,14 @@ pub struct QuantizedSummary<C: ComponentType> {
     dim: usize,
     component_ids: Option<Box<[C]>>,
     offsets: EliasFano,
-    summaries_ids: BitFieldBoxed,
+    summaries_ids: BitField,
     values: Box<[u8]>,
     minimums: Box<[f32]>,
     quants: Box<[f32]>,
 }
 
 use mem_dbg::{MemSize, SizeFlags};
-impl SpaceUsage for BitFieldBoxed {
+impl SpaceUsage for BitField {
     fn space_usage_byte(&self) -> usize {
         self.mem_size(SizeFlags::empty())
     }
@@ -390,7 +390,7 @@ where
             dim: dataset.dim(),
             component_ids: component_ids.map(|c| c.into_boxed_slice()),
             offsets: EliasFano::from(&offsets),
-            summaries_ids: BitFieldBoxed::from(summaries_ids),
+            summaries_ids: BitField::from(summaries_ids),
             values: codes.into_boxed_slice(),
             minimums: minimums.into_boxed_slice(),
             quants: quants.into_boxed_slice(),


### PR DESCRIPTION
Fixed names in the inverted_index.rs and quantized_summary.rs due to a change in the toolkit library
https://github.com/rossanoventurini/toolkit/commit/123eebdd89bba58745189e2b77ad4959d9a43c99